### PR TITLE
feat: Add X mark player icon type

### DIFF
--- a/src/components/FootballCanvas.tsx
+++ b/src/components/FootballCanvas.tsx
@@ -3176,6 +3176,33 @@ const FootballCanvas = forwardRef(({
           />
         )
       }
+      case 'x':
+        return (
+          <Group {...baseProps}>
+            <Line
+              points={[
+                -player.size / 2, -player.size / 2,
+                player.size / 2, player.size / 2
+              ]}
+              stroke={strokeColor}
+              strokeWidth={strokeWidth}
+              shadowColor={isSelected ? '#2563eb' : undefined}
+              shadowBlur={isSelected ? 10 : 0}
+              shadowEnabled={shadowEnabled}
+            />
+            <Line
+              points={[
+                player.size / 2, -player.size / 2,
+                -player.size / 2, player.size / 2
+              ]}
+              stroke={strokeColor}
+              strokeWidth={strokeWidth}
+              shadowColor={isSelected ? '#2563eb' : undefined}
+              shadowBlur={isSelected ? 10 : 0}
+              shadowEnabled={shadowEnabled}
+            />
+          </Group>
+        )
       default:
         return null
     }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -72,7 +72,8 @@ const Sidebar: React.FC<SidebarProps> = ({
     { value: 'triangle', label: '▽' },
     { value: 'square', label: '□' },
     { value: 'chevron', label: '∨' },
-    { value: 'text', label: 'A' }
+    { value: 'text', label: 'A' },
+    { value: 'x', label: '✕' }
   ]
 
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 // プレイヤーの種類
-export type PlayerType = 'circle' | 'triangle' | 'square' | 'text' | 'chevron'
+export type PlayerType = 'circle' | 'triangle' | 'square' | 'text' | 'chevron' | 'x'
 
 // フィールド制約定数
 export const FIELD_CONSTRAINTS = {


### PR DESCRIPTION
- Add 'x' to PlayerType union in types/index.ts
- Add X mark option to Sidebar player type selector with ✕ label
- Implement X mark rendering in FootballCanvas using two diagonal lines
- X mark supports all standard player features (selection, styling, dragging)

🤖 Generated with [Claude Code](https://claude.ai/code)