### PR TITLE
fix: Dynamic center line thickness based on field flip state

### DIFF
--- a/src/components/FootballCanvas.tsx
+++ b/src/components/FootballCanvas.tsx
@@ -2648,13 +2648,16 @@ const FootballCanvas = forwardRef(({
     )
 
     if (play.field.yardLines) {
+      // フィールド反転状態を判定
+      const flipped = isFieldFlipped()
+      
       // 7本の水平線を均等に配置（フィールドを8等分）
       for (let i = 1; i <= 7; i++) {
         const y = (fieldHeight * i) / 8
         let strokeWidth = 2
         
-        // 上から5番目の線は太く
-        if (i === 5) {
+        // 反転時は3番目、通常時は5番目の線を太く
+        if ((flipped && i === 3) || (!flipped && i === 5)) {
           strokeWidth = 4
         }
         


### PR DESCRIPTION
- Add field flip detection in drawField function
- Normal state: 5th line is thick (position 5/8)
- Flipped state: 3rd line is thick (position 3/8)
- Center line thickness now properly follows field orientation

🤖 Generated with [Claude Code](https://claude.ai/code)