### PR TITLE
feat: Update TextBoxPanel character limit from 2 to 3 characters

### DIFF
--- a/src/components/TextBoxPanel.tsx
+++ b/src/components/TextBoxPanel.tsx
@@ -13,8 +13,8 @@ const TextBoxPanel: React.FC<TextBoxPanelProps> = ({
   disabled = false
 }) => {
   const handleShortTextChange = (index: number, value: string) => {
-    // 2文字制限
-    const limitedValue = value.slice(0, 2)
+    // 3文字制限
+    const limitedValue = value.slice(0, 3)
     const updatedEntries = [...textBoxEntries]
     updatedEntries[index] = {
       ...updatedEntries[index],
@@ -49,7 +49,7 @@ const TextBoxPanel: React.FC<TextBoxPanelProps> = ({
       <div className="mb-3">
         <h3 className="text-sm font-medium text-gray-700 mb-2">メモ・説明</h3>
         <div className="text-xs text-gray-500 mb-3">
-          左列：記号・番号（2文字まで）｜ 右列：説明文
+          左列：記号・番号（3文字まで）｜ 右列：説明文
         </div>
       </div>
       
@@ -61,14 +61,14 @@ const TextBoxPanel: React.FC<TextBoxPanelProps> = ({
               {index + 1}
             </div>
             
-            {/* 1列目: 短いテキスト（2文字まで） */}
+            {/* 1列目: 短いテキスト（3文字まで） */}
             <input
               type="text"
               value={entry.shortText}
               onChange={(e) => handleShortTextChange(index, e.target.value)}
-              className="w-12 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-500 text-center"
+              className="w-16 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:border-blue-500 text-center"
               placeholder="記号"
-              maxLength={2}
+              maxLength={3}
             />
             
             {/* 2列目: 長いテキスト */}

--- a/test/components/TextBoxPanel.test.tsx
+++ b/test/components/TextBoxPanel.test.tsx
@@ -43,7 +43,7 @@ describe('TextBoxPanel Component', () => {
       )
       
       expect(screen.getByText('メモ・説明')).toBeInTheDocument()
-      expect(screen.getByText('左列：記号・番号（2文字まで）｜ 右列：説明文')).toBeInTheDocument()
+      expect(screen.getByText('左列：記号・番号（3文字まで）｜ 右列：説明文')).toBeInTheDocument()
       expect(screen.getByText('プレイごとに自動保存されます')).toBeInTheDocument()
     })
 
@@ -111,7 +111,7 @@ describe('TextBoxPanel Component', () => {
   })
 
   describe('テキスト入力機能', () => {
-    test('短いテキストボックスで2文字制限が機能すること', () => {
+    test('短いテキストボックスで3文字制限が機能すること', () => {
       const mockOnUpdate = vi.fn()
       const mockEntries = createMockTextBoxEntries()
       
@@ -125,16 +125,16 @@ describe('TextBoxPanel Component', () => {
       
       const shortTextBox = screen.getAllByPlaceholderText('記号')[0]
       
-      // onChange イベントを直接発生させて2文字制限をテスト
-      fireEvent.change(shortTextBox, { target: { value: 'ABC' } })
+      // onChange イベントを直接発生させて3文字制限をテスト
+      fireEvent.change(shortTextBox, { target: { value: 'ABCD' } })
       
       // 更新関数が呼ばれること
       expect(mockOnUpdate).toHaveBeenCalled()
       
-      // 2文字制限が適用されていることを確認
+      // 3文字制限が適用されていることを確認
       const calls = mockOnUpdate.mock.calls
       const lastCall = calls[calls.length - 1]
-      expect(lastCall[0][0].shortText).toBe('AB') // 2文字に制限される
+      expect(lastCall[0][0].shortText).toBe('ABC') // 3文字に制限される
     })
 
     test('長いテキストボックスで文字制限がないこと', () => {
@@ -216,7 +216,7 @@ describe('TextBoxPanel Component', () => {
       
       // 短いテキストボックスの属性確認
       expect(shortTextBoxes[0]).toHaveAttribute('type', 'text')
-      expect(shortTextBoxes[0]).toHaveAttribute('maxLength', '2')
+      expect(shortTextBoxes[0]).toHaveAttribute('maxLength', '3')
       
       // 長いテキストボックスの属性確認
       expect(longTextBoxes[0]).toHaveAttribute('type', 'text')


### PR DESCRIPTION
記号・番号テキストボックスの文字制限を2文字から3文字に変更

- shortText制限を2文字から3文字に拡張（value.slice(0, 3)）
- maxLength属性を2から3に更新
- 入力フィールドの幅をw-12からw-16に調整（3文字対応）
- UIテキストを「2文字まで」から「3文字まで」に更新
- テストケース更新：
  - テストケース名を「3文字制限」に変更
  - テスト入力を'ABCD'に変更、期待値を'ABC'に更新
  - maxLength属性テストを'3'に更新

🤖 Generated with [Claude Code](https://claude.ai/code)