### PR TITLE
feat: Phase3自動バックアップからの復元UI機能を実装

### DIFF
--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -369,7 +369,10 @@ export function SettingsModal({ isOpen, onClose, onSuccess, onError }: SettingsM
                         <div className="flex-1">
                           <div className="text-sm font-medium text-gray-900">{backup.filename}</div>
                           <div className="text-xs text-gray-500">
-                            {backup.createdAt.toLocaleString('ja-JP')} • {formatFileSize(backup.size)}
+                            {(backup.createdAt instanceof Date 
+                              ? backup.createdAt 
+                              : new Date(backup.createdAt)
+                            ).toLocaleString('ja-JP')} • {formatFileSize(backup.size)}
                           </div>
                         </div>
                         <div className="flex space-x-2">
@@ -435,7 +438,10 @@ export function SettingsModal({ isOpen, onClose, onSuccess, onError }: SettingsM
                 <div className="bg-gray-50 rounded-lg p-3">
                   <div className="text-sm font-medium text-gray-900">{selectedBackup.filename}</div>
                   <div className="text-xs text-gray-500">
-                    {selectedBackup.createdAt.toLocaleString('ja-JP')} • {formatFileSize(selectedBackup.size)}
+                    {(selectedBackup.createdAt instanceof Date 
+                      ? selectedBackup.createdAt 
+                      : new Date(selectedBackup.createdAt)
+                    ).toLocaleString('ja-JP')} • {formatFileSize(selectedBackup.size)}
                   </div>
                 </div>
               </div>

--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { SettingsStorage } from '@/utils/storage'
 import { AutoBackupManager } from '@/utils/autoBackup'
+import { ImportResult } from '@/utils/backup'
 import { AppSettings, AutoBackupSettings } from '@/types'
 
 interface SettingsModalProps {
@@ -15,6 +16,12 @@ export function SettingsModal({ isOpen, onClose, onSuccess, onError }: SettingsM
   const [autoBackupHistory, setAutoBackupHistory] = useState<any[]>([])
   const [loading, setLoading] = useState(false)
   const [activeTab, setActiveTab] = useState<'general' | 'autoBackup'>('general')
+  const [restoreDialogOpen, setRestoreDialogOpen] = useState(false)
+  const [selectedBackup, setSelectedBackup] = useState<any>(null)
+  const [restoreOptions, setRestoreOptions] = useState({
+    overwrite: true,
+    skipDuplicates: false
+  })
 
   // 設定を読み込み
   useEffect(() => {
@@ -122,6 +129,47 @@ export function SettingsModal({ isOpen, onClose, onSuccess, onError }: SettingsM
       console.error('バックアップのダウンロードに失敗しました:', error)
       onError('バックアップのダウンロードに失敗しました')
     }
+  }
+
+  const handleRestoreAutoBackup = (backupId: string) => {
+    const backup = autoBackupHistory.find(b => b.id === backupId)
+    if (backup) {
+      setSelectedBackup(backup)
+      setRestoreDialogOpen(true)
+    }
+  }
+
+  const handleConfirmRestore = async () => {
+    if (!selectedBackup) return
+
+    try {
+      setLoading(true)
+      const result = await AutoBackupManager.restoreFromAutoBackup(
+        selectedBackup.id,
+        restoreOptions
+      ) as ImportResult
+      
+      if (result.success) {
+        onSuccess(`復元が完了しました: プレイ${result.imported.plays}個、プレイリスト${result.imported.playlists}個、フォーメーション${result.imported.formations}個を復元しました`)
+        setRestoreDialogOpen(false)
+        setSelectedBackup(null)
+      } else {
+        onError(result.message)
+        if (result.errors && result.errors.length > 0) {
+          console.error('復元エラー詳細:', result.errors)
+        }
+      }
+    } catch (error) {
+      console.error('復元に失敗しました:', error)
+      onError('復元に失敗しました')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCancelRestore = () => {
+    setRestoreDialogOpen(false)
+    setSelectedBackup(null)
   }
 
   const formatFileSize = (bytes: number): string => {
@@ -332,6 +380,13 @@ export function SettingsModal({ isOpen, onClose, onSuccess, onError }: SettingsM
                             ダウンロード
                           </button>
                           <button
+                            onClick={() => handleRestoreAutoBackup(backup.id)}
+                            className="text-xs px-2 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200"
+                            disabled={loading}
+                          >
+                            復元
+                          </button>
+                          <button
                             onClick={() => handleDeleteAutoBackup(backup.id)}
                             className="text-xs px-2 py-1 bg-red-100 text-red-700 rounded hover:bg-red-200"
                           >
@@ -365,6 +420,80 @@ export function SettingsModal({ isOpen, onClose, onSuccess, onError }: SettingsM
           </button>
         </div>
       </div>
+
+      {/* 復元確認ダイアログ */}
+      {restoreDialogOpen && selectedBackup && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full">
+            <div className="p-6">
+              <h3 className="text-lg font-medium text-gray-900 mb-4">
+                バックアップの復元
+              </h3>
+              
+              <div className="mb-4">
+                <div className="text-sm text-gray-600 mb-2">復元するバックアップ:</div>
+                <div className="bg-gray-50 rounded-lg p-3">
+                  <div className="text-sm font-medium text-gray-900">{selectedBackup.filename}</div>
+                  <div className="text-xs text-gray-500">
+                    {selectedBackup.createdAt.toLocaleString('ja-JP')} • {formatFileSize(selectedBackup.size)}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mb-6 space-y-3">
+                <div className="text-sm font-medium text-gray-700">復元オプション:</div>
+                
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={restoreOptions.overwrite}
+                    onChange={(e) => setRestoreOptions(prev => ({ ...prev, overwrite: e.target.checked }))}
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  />
+                  <span className="ml-2 text-sm text-gray-700">
+                    既存のデータを上書きする
+                  </span>
+                </label>
+
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={restoreOptions.skipDuplicates}
+                    onChange={(e) => setRestoreOptions(prev => ({ ...prev, skipDuplicates: e.target.checked }))}
+                    className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                  />
+                  <span className="ml-2 text-sm text-gray-700">
+                    重複するデータをスキップする
+                  </span>
+                </label>
+              </div>
+
+              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-6">
+                <div className="text-xs text-yellow-800">
+                  ⚠️ 復元を実行すると、現在のデータが変更される可能性があります。事前にバックアップを作成することをお勧めします。
+                </div>
+              </div>
+
+              <div className="flex space-x-3">
+                <button
+                  onClick={handleCancelRestore}
+                  className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  disabled={loading}
+                >
+                  キャンセル
+                </button>
+                <button
+                  onClick={handleConfirmRestore}
+                  className="flex-1 px-4 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  disabled={loading}
+                >
+                  {loading ? '復元中...' : '復元実行'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/utils/autoBackup.ts
+++ b/src/utils/autoBackup.ts
@@ -1,4 +1,4 @@
-import { BackupManager, BackupData } from './backup'
+import { BackupManager, BackupData, ImportResult } from './backup'
 import { SettingsStorage } from './storage'
 import { AutoBackupSettings } from '../types'
 
@@ -216,7 +216,7 @@ export class AutoBackupManager {
   static async restoreFromAutoBackup(backupId: string, options?: {
     overwrite?: boolean
     skipDuplicates?: boolean
-  }) {
+  }): Promise<ImportResult> {
     try {
       const backups = await this.getAutoBackupList()
       const backup = backups.find(b => b.id === backupId)
@@ -224,7 +224,9 @@ export class AutoBackupManager {
       if (!backup) {
         return {
           success: false,
-          message: '指定されたバックアップファイルが見つかりません'
+          message: '指定されたバックアップファイルが見つかりません',
+          imported: { plays: 0, playlists: 0, formations: 0, settingsRestored: false },
+          errors: ['指定されたバックアップファイルが見つかりません']
         }
       }
 


### PR DESCRIPTION
- 自動バックアップ履歴に「復元」ボタンを追加
- 復元確認ダイアログを実装（復元オプション付き）
- 復元処理のUI連携ロジックを追加
- 復元進行状況表示とエラーハンドリングを実装
- 復元完了時の詳細通知機能を追加

📋 実装内容:
- handleRestoreAutoBackup: 復元ボタンクリック時の処理
- handleConfirmRestore: 復元実行処理（ImportResult型対応）
- handleCancelRestore: 復元キャンセル処理
- 復元確認ダイアログUI（上書き・重複スキップオプション）
- 復元前の警告メッセージ表示

🎯 Phase3目標達成: 自動バックアップからの復元UI機能完成

🤖 Generated with [Claude Code](https://claude.ai/code)