### PR TITLE
fix: 上下反転時の三角・chevronプレーヤーの向き問題を修正

### DIFF
--- a/src/components/FootballCanvas.tsx
+++ b/src/components/FootballCanvas.tsx
@@ -1074,7 +1074,9 @@ const FootballCanvas = forwardRef(({
         size: 20,
         team: appState.selectedTeam,
         text: appState.selectedPlayerType === 'text' ? 'A' : undefined,
-        flipped: false // デフォルトは反転していない状態
+        flipped: (appState.selectedPlayerType === 'triangle' || appState.selectedPlayerType === 'chevron') 
+          ? isFieldFlipped() 
+          : false // triangle/chevronは上下反転状態に応じて向きを設定
       }
 
       onUpdatePlay({


### PR DESCRIPTION
- プレーヤー作成時にisFieldFlipped()の結果を使ってflippedフィールドを設定
- triangleとchevronタイプのプレーヤーのみ上下反転状態に応じて向きを調整
- 上下反転時に新規配置されるプレーヤーが正しい向きで表示されるように改善

🤖 Generated with [Claude Code](https://claude.ai/code)